### PR TITLE
Import Client class, not the type

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -1,4 +1,5 @@
-import { Client, createClient } from "gel";
+import { createClient } from "gel";
+import { Client } from "gel/dist/baseClient";
 
 import { isNullOrUndefined } from "./util";
 


### PR DESCRIPTION
We only export the `Client` type from the main module, so dig into the internals to get the actual class. Gel will look into exporting the class as well in the future.